### PR TITLE
add registration info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ $ dokku proxy:ports-add gitlab-runner http:8080:5000
 # Local
 $ git add remote dokku@host_ip:gitlab-runner
 $ git push origin dokku
+
+# Host
+$ dokku run gitlab-runner register
+$ dokku ps:restart
 ```


### PR DESCRIPTION
Thanks for this little repo, it probably just saved me half an hour of googling.

Added the host commands required to register the gitlab-runner with gitlab after deployment.